### PR TITLE
Fix musl ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,15 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-src"
-version = "111.7.0+1.1.1e"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fde5a8c01ef8aa31ff8d0aaf9bae248581ed8840fca0b66e51cc9f294a8cb2c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,7 +744,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
+name = "cc"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +278,21 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -577,6 +598,7 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
+ "openssl",
  "prost",
  "prost-types",
  "r2d2",
@@ -700,6 +722,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +837,12 @@ name = "pin-utils"
 version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "postgis"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.7.0+1.1.1e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fde5a8c01ef8aa31ff8d0aaf9bae248581ed8840fca0b66e51cc9f294a8cb2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +753,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ r2d2 = "0.8"
 tokio = { version = "0.2", features = ["macros"] }
 tonic = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+openssl = "*"
 
 [build-dependencies]
 tonic-build = { version = "0.1.1", default-features = false, features = ["transport"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ r2d2 = "0.8"
 tokio = { version = "0.2", features = ["macros"] }
 tonic = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-openssl = "*"
+openssl = { version = "0.10.28", features = ["vendored"] }
 
 [build-dependencies]
 tonic-build = { version = "0.1.1", default-features = false, features = ["transport"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ r2d2 = "0.8"
 tokio = { version = "0.2", features = ["macros"] }
 tonic = "0.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-openssl = { version = "0.10.28", features = ["vendored"] }
+openssl = "*"
 
 [build-dependencies]
 tonic-build = { version = "0.1.1", default-features = false, features = ["transport"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clux/muslrust:1.42.0-stable as cargo-build
+FROM ekidd/rust-musl-builder:1.42.0 as cargo-build
 
 COPY . .
 
@@ -6,7 +6,9 @@ RUN cargo install --path .
 
 FROM alpine:latest
 
-COPY --from=cargo-build /root/.cargo/bin/lieferemma /usr/local/bin/lieferemma
+
+
+COPY --from=cargo-build /home/rust/.cargo/bin/lieferemma /usr/local/bin/lieferemma
 
 ENV RUST_LOG=info
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder:1.42.0 as cargo-build
+FROM clux/muslrust:1.42.0-stable as cargo-build
 
 COPY . .
 
@@ -8,7 +8,7 @@ FROM alpine:latest
 
 
 
-COPY --from=cargo-build /home/rust/.cargo/bin/lieferemma /usr/local/bin/lieferemma
+COPY --from=cargo-build /root/.cargo/bin/lieferemma /usr/local/bin/lieferemma
 
 ENV RUST_LOG=info
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![CI](https://github.com/lieferemma/backend/workflows/CI/badge.svg)
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Cargo-Deny](https://img.shields.io/badge/cargo--deny-Dependencies%20checked-blue)
-[![](https://images.microbadger.com/badges/image/lieferemma/backend.svg)](https://microbadger.com/images/lieferemma/backend)
+[![](https://img.shields.io/docker/image-size/lieferemma/backend)](https://hub.docker.com/r/lieferemma/backend)
 [![](https://img.shields.io/discord/692016139697651722)](https://discord.gg/rWWpxYG)
 
 # Current State

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+extern crate openssl;
 #[macro_use]
 extern crate diesel;
 
@@ -17,6 +18,7 @@ use tonic::transport::Server;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+
     let opt = Opt::from_args();
 
     let pg_connection_manager = ConnectionManager::new(opt.database_url());

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use tonic::transport::Server;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-
     let opt = Opt::from_args();
 
     let pg_connection_manager = ConnectionManager::new(opt.database_url());


### PR DESCRIPTION
My bad, I think the problem with using a vendored build is that it probably means you compile and statically link a different version than the one libpg (postgres lib) uses which is included in the musl docker image.