### PR TITLE
Add env variables to docker-compose, closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 Build and run from source using docker-compose:
 
 ```
-docker-compose up -d
+docker-compose pull && docker-compose up -d
 ```
 
 To avoid rebuilding the backend docker image during development you should directly run cargo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3.7'
 
 services:
   lieferemma-backend:
-    build: .
+    image: lieferemma/backend:latest
+    environment:
+      GRPC_API_ADDR: 0.0.0.0:50051
+      DATABASE_URL: postgres://postgres:changeme@localhost/lieferemma
     ports:
       - "50051:50051"
     networks:


### PR DESCRIPTION
Also decided to switch to the image. I assume during dev flow people use cargo anyway as it does not make sense to rebuild everytime.